### PR TITLE
Fix/nothing word array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tech-bureau-jp/symbol-sdk",
-    "version": "1.0.3-comsa-2022062201",
+    "version": "1.0.3-comsa-2022062801",
     "description": "Reactive symbol sdk for typescript and javascript",
     "scripts": {
         "pretest": "npm run build",

--- a/src/core/crypto/Utilities.ts
+++ b/src/core/crypto/Utilities.ts
@@ -15,7 +15,6 @@
  */
 
 import * as CryptoJS from 'crypto-js';
-import { WordArray } from 'crypto-js';
 import * as hkdf from 'futoin-hkdf';
 import { sha512 } from 'js-sha512';
 import { RawArray as array } from '../format';
@@ -34,7 +33,7 @@ export const Half_Hash_Size = Hash_Size / 2;
  *
  * @return {WordArray}
  */
-export const ua2words = (ua, uaLength): WordArray => {
+export const ua2words = (ua, uaLength): any => {
     const temp: number[] = [];
     for (let i = 0; i < uaLength; i += 4) {
         const x = ua[i] * 0x1000000 + (ua[i + 1] || 0) * 0x10000 + (ua[i + 2] || 0) * 0x100 + (ua[i + 3] || 0);


### PR DESCRIPTION
別リポジトリで使用してbuildしたときに以下のエラー

`Cannot find name 'WordArray'.`

```
$ tsc --project .
node_modules/@tech-bureau-jp/symbol-sdk/dist/src/core/crypto/Utilities.d.ts:14:60 - error TS2304: Cannot find name 'WordArray'.

14 export declare const ua2words: (ua: any, uaLength: any) => WordArray;
                                                              ~~~~~~~~~
Found 1 error in node_modules/@tech-bureau-jp/symbol-sdk/dist/src/core/crypto/Utilities.d.ts:14
```

build後ちゃんと変わってたのでいけるはず。。

```
mnaoki@mnaoki ~/d/g/t/symbol-sdk (fix/nothing-WordArray)> cat dist/src/core/crypto/Utilities.d.ts | grep ua2words                                                               15:44:03
export declare const ua2words: (ua: any, uaLength: any) => any;
```